### PR TITLE
added tile highlight object

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,7 +23,7 @@ export const UNIT_FIRE_RATE_MS = 100;
 export const UNIT_SQUAD_SIZE = 5;
 export const UNIT_SNAP_DISTANCE = 2;
 export const UNIT_MOVING_TINT = 0xc0392b;
-export const UNIT_SELECTED_TINT = 0xf1c40f;
+export const UNIT_SELECTED_TILE_BORDER = 0x0000ff;
 
 export const BOARD_WIDTH_TILE = BOARD_WIDTH / TILE_SIZE;
 export const BOARD_HEIGHT_TILE = BOARD_HEIGHT / TILE_SIZE;
@@ -61,12 +61,14 @@ export const INDICATOR_INVALID_SELECTION_COLOR = 0xc0392b;
 export const INDICATOR_OPACITY = 0.75;
 
 type TileCoordinateOffset = {
-  i: number,
-  j: number
-}
+  i: number;
+  j: number;
+};
 
-export const AVAILABLE_FORMATIONS: { [key: string]: Array<TileCoordinateOffset> } = {
-  'auto': [
+export const AVAILABLE_FORMATIONS: {
+  [key: string]: Array<TileCoordinateOffset>;
+} = {
+  auto: [
     { i: 0, j: 0 },
     { i: 0, j: 1 },
     { i: 1, j: 0 },
@@ -75,23 +77,23 @@ export const AVAILABLE_FORMATIONS: { [key: string]: Array<TileCoordinateOffset> 
     { i: 1, j: 1 },
     { i: 1, j: -1 },
     { i: -1, j: 1 },
-    { i: -1, j: -1 }
+    { i: -1, j: -1 },
   ],
-  'horizontal': [
+  horizontal: [
     { i: 0, j: 0 },
     { i: 0, j: 1 },
     { i: 0, j: -1 },
     { i: 0, j: 2 },
-    { i: 0, j: -2 }
+    { i: 0, j: -2 },
   ],
-  'vertical': [
+  vertical: [
     { i: 0, j: 0 },
     { i: 1, j: 0 },
     { i: -1, j: 0 },
     { i: 2, j: 0 },
-    { i: -2, j: 0 }
-  ]
-}
+    { i: -2, j: 0 },
+  ],
+};
 
 export const DEFAULT_FORMATION_SHAPE = 'auto';
 

--- a/src/entities/TileHighlight.ts
+++ b/src/entities/TileHighlight.ts
@@ -1,0 +1,87 @@
+import { Scene } from 'phaser';
+import { TILE_SIZE } from '../constants';
+import { generateId } from '../utils';
+
+export class TileHighlight {
+  id: string;
+
+  lineColour: number;
+  fillColour: number;
+  borderSize: number;
+
+  shape: Phaser.GameObjects.Graphics;
+
+  xPos: number;
+  yPos: number;
+
+  constructor(
+    scene: Scene,
+    borderSize: number,
+    lineColour: number,
+    fillColour = -1
+  ) {
+    this.id = generateId('TileHighlight');
+
+    this.shape = new Phaser.GameObjects.Graphics(scene);
+    scene.add.existing(this.shape);
+
+    this.xPos = -100;
+    this.yPos = -100;
+
+    this.lineColour = lineColour;
+    this.fillColour = fillColour >= 0 ? fillColour : null;
+    this.borderSize = borderSize;
+  }
+
+  /**
+   * @deprecated Use #updatePositionByTile instead
+   */
+  updatePosition(xPos: number, yPos: number) {
+    this.xPos = xPos;
+    this.yPos = yPos;
+  }
+
+  updatePositionByTile(tileRow: number, tileCol: number) {
+    this.xPos = tileCol * TILE_SIZE;
+    this.yPos = tileRow * TILE_SIZE;
+
+    return this;
+  }
+
+  clear() {
+    this.shape.clear();
+
+    return this;
+  }
+
+  destory() {
+    this.shape.destroy();
+  }
+
+  draw() {
+    this.clear();
+
+    const LINE_WIDTH = this.borderSize;
+    const LINE_COLOUR = this.lineColour;
+    const FILL_COLOUR = this.fillColour ?? this.lineColour;
+
+    const x = this.xPos,
+      y = this.yPos;
+
+    this.shape.moveTo(x, y);
+    this.shape.lineStyle(LINE_WIDTH, LINE_COLOUR);
+    this.shape.fillStyle(FILL_COLOUR, 0.25);
+
+    this.shape.beginPath();
+    this.shape.lineTo(x + TILE_SIZE, y);
+    this.shape.lineTo(x + TILE_SIZE, y + TILE_SIZE);
+    this.shape.lineTo(x, y + TILE_SIZE);
+    this.shape.lineTo(x, y);
+
+    this.shape.closePath();
+    this.shape.fillPath();
+    this.shape.strokePath();
+
+    return this;
+  }
+}


### PR DESCRIPTION
- added `TileHighlight` object, works similar to the `HealthBar` object.
- replaced unit selected tint with tile highlight highlight follows unit during moves

https://user-images.githubusercontent.com/11997716/197935890-4fc0862c-c083-4f40-abdb-57e900130b8c.mov

