### PR TITLE
add touch assist button for moving units

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -31,8 +31,8 @@
   </head>
   <body>
     <div id="content" style="height: 512px"></div>
-    <div id="controls">
-      <table>
+    <div id="controls" style="margin-top: 16px">
+      <table style="margin: auto">
         <tr>
           <th>Key Bindings</th>
           <th>Action</th>

--- a/src/entities/Button.ts
+++ b/src/entities/Button.ts
@@ -1,0 +1,35 @@
+import { Scene } from 'phaser';
+
+export class Button extends Phaser.GameObjects.Text {
+  constructor(
+    scene: Scene,
+    x: number,
+    y: number,
+    text: string,
+    callback: () => void,
+    style?: Phaser.Types.GameObjects.Text.TextStyle
+  ) {
+    super(scene, x, y, text, style as Phaser.Types.GameObjects.Text.TextStyle);
+
+    this.scene.add.existing(this);
+    this.setInteractive({ useHandCursor: true })
+      .on('pointerover', () => this.enterButtonHoverState())
+      .on('pointerout', () => this.enterButtonRestState())
+      .on('pointerdown', () => this.enterButtonActiveState())
+      .on('pointerup', () => {
+        this.enterButtonHoverState();
+        callback();
+      });
+  }
+  enterButtonHoverState() {
+    this.setStyle({ fill: '#ff0' });
+  }
+
+  enterButtonRestState() {
+    this.setStyle({ fill: '#0f0' });
+  }
+
+  enterButtonActiveState() {
+    this.setStyle({ fill: '#0ff' });
+  }
+}

--- a/src/entities/Pointer.ts
+++ b/src/entities/Pointer.ts
@@ -22,18 +22,15 @@ class Pointer extends Phaser.GameObjects.GameObject {
 
   x: number;
   y: number;
-  map: number[][];
 
   debugTileHighlighterToggleKey: Phaser.Input.Keyboard.Key;
 
   constructor(scene: Game) {
     super(scene, 'Pointer');
 
-    this.map = scene.map;
-
     this.debugTileHighlighterToggleKey =
       this.scene.input.keyboard.addKey('CTRL');
-    this.indicator = scene.add.graphics();
+    this.indicator = scene.add.graphics().setDepth(1000);
     this.indicatorDebugText = scene.add
       .text(BOARD_WIDTH, BOARD_HEIGHT, '')
       .setDepth(1000)
@@ -49,16 +46,18 @@ class Pointer extends Phaser.GameObjects.GameObject {
     );
   }
 
+  gameScene() {
+    return this.scene as Game;
+  }
+
   isDebugKeyDown() {
-    return this.scene.input.keyboard.checkDown(
-      this.debugTileHighlighterToggleKey
-    );
+    return this.gameScene().keyIsDown(this.debugTileHighlighterToggleKey);
   }
 
   update() {
     this.indicator.clear();
     this.indicatorDebugText.setText('');
-    const entities = (this.scene as Game).entities;
+    const entities = this.gameScene().entities;
 
     const selectedUnitCount = entities.selectedUnitGroup.size();
     const hasSelectedUnits = selectedUnitCount > 0;
@@ -68,13 +67,16 @@ class Pointer extends Phaser.GameObjects.GameObject {
         this.x,
         this.y,
         entities.selectedUnitGroup.getUnits(),
-        this.map,
+        this.gameScene().map,
         entities.interaction
       );
 
       const hasSpaceForUnits = validUnitFormation.length >= selectedUnitCount;
 
-      if (hasSpaceForUnits && isTileFreeAtPosition(this.x, this.y, this.map)) {
+      if (
+        hasSpaceForUnits &&
+        isTileFreeAtPosition(this.x, this.y, this.gameScene().map)
+      ) {
         this.indicator.fillStyle(
           INDICATOR_VALID_SELECTION_COLOR,
           INDICATOR_OPACITY

--- a/src/entities/Pointer.ts
+++ b/src/entities/Pointer.ts
@@ -41,7 +41,13 @@ class Pointer extends Phaser.GameObjects.GameObject {
 
     scene.input.on(
       Phaser.Input.Events.POINTER_MOVE as string,
-      this.handlePointerMove,
+      this.setPositionToPointerPosition,
+      this
+    );
+
+    scene.input.on(
+      Phaser.Input.Events.POINTER_DOWN as string,
+      this.setPositionToPointerPosition,
       this
     );
   }
@@ -113,7 +119,7 @@ class Pointer extends Phaser.GameObjects.GameObject {
     }
   }
 
-  handlePointerMove = (pointer: Phaser.Input.Pointer) => {
+  setPositionToPointerPosition = (pointer: Phaser.Input.Pointer) => {
     const { row, col } = getTileRowColBySceneXY(pointer.x, pointer.y);
 
     this.x = col * TILE_SIZE;

--- a/src/entities/Unit.ts
+++ b/src/entities/Unit.ts
@@ -55,15 +55,12 @@ export class Unit extends Phaser.GameObjects.Image {
   tilePositionRow = -100;
   tilePositionCol = -100;
 
-  map: number[][];
-
   STATES = STATES; // { SEIGED: 'SEIGED', PREPARING: 'PREPARING', MOVING: 'MOVING' };
 
   constructor(scene: Game, _spriteKey = UNIT_IMG_NAME__NORMAL) {
     super(scene, 0, 0, SPRITE_ATLAS_NAME, _spriteKey);
 
     this.id = generateId('Unit');
-    this.map = scene.map;
 
     logger.log('### NEW TANKY', this);
 
@@ -86,6 +83,10 @@ export class Unit extends Phaser.GameObjects.Image {
     );
   }
 
+  gameScene() {
+    return this.scene as Game;
+  }
+
   getDamage() {
     return BULLET_DAMAGE;
   }
@@ -103,7 +104,7 @@ export class Unit extends Phaser.GameObjects.Image {
   }
 
   toString() {
-    const entities = (this.scene as Game).entities;
+    const entities = this.gameScene().entities;
     const selected = entities.selectedUnitGroup.hasUnit(this) ? '*' : '';
 
     let movingStatus = '';
@@ -139,7 +140,7 @@ export class Unit extends Phaser.GameObjects.Image {
     this.target.x = this.x;
     this.target.y = this.y;
 
-    this.map[this.tilePositionRow][this.tilePositionCol] =
+    this.gameScene().map[this.tilePositionRow][this.tilePositionCol] =
       OCCUPIED_UNIT_POSITION;
   }
 
@@ -154,7 +155,7 @@ export class Unit extends Phaser.GameObjects.Image {
   }
 
   shootBullet(enemy: Enemy) {
-    const entities = (this.scene as Game).entities;
+    const entities = this.gameScene().entities;
     const bullet = entities.bullets.get() as Bullet | null;
 
     if (bullet) {
@@ -265,7 +266,8 @@ export class Unit extends Phaser.GameObjects.Image {
     const { x: tilePositionCol, y: tilePositionRow } = finalPosition;
 
     // mark current tile as vacant
-    this.map[this.tilePositionRow][this.tilePositionCol] = VALID_UNIT_POSITION;
+    this.gameScene().map[this.tilePositionRow][this.tilePositionCol] =
+      VALID_UNIT_POSITION;
 
     this.tilePositionRow = tilePositionRow;
     this.tilePositionCol = tilePositionCol;
@@ -282,7 +284,7 @@ export class Unit extends Phaser.GameObjects.Image {
     this._queuedPath = [];
 
     // mark final tile as occupied
-    this.map[this.tilePositionRow][this.tilePositionCol] =
+    this.gameScene().map[this.tilePositionRow][this.tilePositionCol] =
       OCCUPIED_UNIT_POSITION;
   }
 
@@ -303,7 +305,7 @@ export class Unit extends Phaser.GameObjects.Image {
   }
 
   update(time: number, delta: number) {
-    const entities = (this.scene as Game).entities;
+    const entities = this.gameScene().entities;
 
     if (this.isMoving()) {
       this.setTint(UNIT_MOVING_TINT);
@@ -340,11 +342,10 @@ export class Unit extends Phaser.GameObjects.Image {
   }
 
   handlePointerDown = (pointer: Phaser.Input.Pointer) => {
-    const entities = (this.scene as Game).entities;
-    const keysDuringPointerEvent =
-      pointer.event as unknown as Phaser.Input.Keyboard.Key;
+    const game = this.gameScene();
+    const entities = game.entities;
 
-    if (keysDuringPointerEvent.shiftKey) {
+    if (game.keyIsDown(game.KEYS.SHIFT)) {
       entities.selectedUnitGroup.toggleUnit(this);
     } else {
       entities.selectedUnitGroup.clearUnits();
@@ -353,7 +354,7 @@ export class Unit extends Phaser.GameObjects.Image {
   };
 
   getEnemy(x: number, y: number, distance: number) {
-    const entities = (this.scene as Game).entities;
+    const entities = this.gameScene().entities;
     // TODO: should also allow biasing for enemies closer to HomeBase
     const enemyUnits = entities.enemyGroup.getChildren() as Array<Enemy>;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,11 +15,14 @@ import { PauseMenu } from './scenes/PauseMenu';
 import { GameOver } from './scenes/GameOver';
 
 const config: Phaser.Types.Core.GameConfig = {
-  type: Phaser.AUTO,
-  parent: 'content',
-  width: BOARD_WIDTH,
-  height: BOARD_HEIGHT,
   backgroundColor: BOARD_BACKGROUND_COLOR,
+  scale: {
+    mode: Phaser.Scale.FIT,
+    parent: 'content',
+    autoCenter: Phaser.Scale.CENTER_HORIZONTALLY,
+    width: BOARD_WIDTH,
+    height: BOARD_HEIGHT,
+  },
   physics: {
     arcade: {
       debug: hasDebugFlag('show-physics-box'),
@@ -61,7 +64,9 @@ new Phaser.Game(config);
     (key) => (isAllEnabled = isAllEnabled && LOGGING_CONFIG[key])
   );
 
-  document.querySelector('#logging-controls')!.innerHTML = `<table>
+  document.querySelector(
+    '#logging-controls'
+  )!.innerHTML = `<table style="margin: auto">
         <tr>
           <th>Logging Key</th>
           <th><input id="enable-all" type="checkbox" title="enable/disable all" ${


### PR DESCRIPTION
- game screen view is responsive to viewport changes
- move/select button is available for moving units with primary click (touch devices only)

https://user-images.githubusercontent.com/11997716/202611492-042f435b-ffea-4565-b3fd-246ab4d69fba.mov

