### PR TITLE
Add wave logic and simplify unit spawning

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,14 +15,19 @@ export const BULLET_IMG_NAME = '17.png';
 export const ENEMY_IMG_NAME = '05.png';
 export const HOMEBASE_TEXTURE_NAME = 'homebase';
 
+export const WAVE_STATES = {
+  SPAWNING: 'SPAWNING',
+  WAITING: 'WAITING'
+}
+
 export const TILE_SIZE = SPRITE_SIZE;
 
 export const BULLET_DAMAGE = 50;
-export const ENEMY_HP = 1500;
-export const ENEMY_SPAWN_RATE_MS = 1000;
-export const ENEMY_SPEED = 1 / 10000;
+export const ENEMY_HP = 500;
+export const ENEMY_SPAWN_RATE_MS = 300;
+export const ENEMY_SPEED = 1 / 20000;
 
-export const HOMEBASE_HP = 100_000;
+export const HOMEBASE_HP = 1000;
 export const HOMEBASE__SHAKE_DURATION = 200;
 export const HOMEBASE__SHAKE_INTENSITY = 0.0125 / 2;
 export const HOMEBASE_DAMAGED_TINT = 0xff0000;
@@ -30,13 +35,12 @@ export const HOMEBASE_DEAD_TINT = 0x0f0f0f;
 
 export const UNIT_FIRE_RANGE = 100;
 export const UNIT_FIRE_RATE_MS = 100;
-export const UNIT_SQUAD_SIZE = 5;
 export const UNIT_SNAP_DISTANCE = 2;
 export const UNIT_MOVING_TINT = 0xc0392b;
 export const UNIT_SELECTED_TILE_BORDER = 0x0000ff;
 export const UNIT_SELECTED_TINT = 0xf1c40f;
 export const UNIT_PREPARING_TINT = 0x808080;
-export const UNIT_PREPARING_ANIMATION_DELAY_MS = 2_000;
+export const UNIT_PREPARING_ANIMATION_DELAY_MS = 500;
 
 export const BOARD_WIDTH_TILE = BOARD_WIDTH / TILE_SIZE;
 export const BOARD_HEIGHT_TILE = BOARD_HEIGHT / TILE_SIZE;

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -1,6 +1,4 @@
-import { Scene } from 'phaser';
-
-import { DEFAULT_FORMATION_SHAPE, UNIT_SQUAD_SIZE } from './constants';
+import { DEFAULT_FORMATION_SHAPE } from './constants';
 import Bullet from './entities/Bullet';
 import Enemy from './entities/Enemy';
 import HomeBase from './entities/HomeBase';
@@ -76,8 +74,7 @@ export const entityManagerFactory = (scene: Game) => {
     } as Phaser.Types.GameObjects.Group.GroupCreateConfig),
     unitGroup: scene.add.group({
       classType: Unit,
-      runChildUpdate: true,
-      maxSize: UNIT_SQUAD_SIZE,
+      runChildUpdate: true
       // use createCallback to pass the scene for post initialization stuff
       // createCallback: function (unit: Unit) {
       //   console.log('### Unit Created', unit.id, unit);

--- a/src/entities/Unit.ts
+++ b/src/entities/Unit.ts
@@ -501,7 +501,7 @@ export const UnitType = {
   NORMAL: Unit,
   SPEEDY: SpeedyUnit,
   CHONKY: ChonkyUnit,
-  SNIPEY: SnipeyUnit,
+  SNIPEY: SnipeyUnit
 };
 
 export type UnitTypeOption = keyof typeof UnitType;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -15,5 +15,10 @@ type TileProperties = {
   crossing: boolean
 }
 
+type Wave = {
+  enemies: number[];
+  delay: number;
+}
+
 // should be "NonNegativeInteger" but that doesn't exist
 type MapPath = Array<{ x: number; y: number }>;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -2,6 +2,7 @@ const LOGGING_CONFIG = {
   _ENABLE_ALL: false,
   DEBUG_HUD__KEYBOARD_STATUS: false,
   DEBUG_HUD__UNIT_STATUS: false,
+  DEBUG_HUD__HOME_BASE_HP: false,
   GAME_SCENE: false,
   GENERIC_DEBUG: false,
   UNIT_STATE_MACHINE: false,


### PR DESCRIPTION
https://user-images.githubusercontent.com/6453335/202886976-8f4f7902-0e69-4fc4-b92d-bcd8d577bf1a.mov

- Add wave logic
- Remove unit limit (in preparation for unit purchasing and roguelite elements)
- Add waveStates
- Trigger UI message when wave changes
- Wrap HUD elements under more debug flags
- Adjust gameplay configurations (health, damage, etc.)