### PR TITLE
Add configuration proxy for real time configuration tweaking

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -94,6 +94,7 @@
       id="config-debug"
       style="
         position: fixed;
+        pointer-events: all;
         top: 0;
         right: 0;
         width: 300px;

--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,40 @@
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="TaNkYbOiZ" />
     <title>TaNkYbOiZ</title>
+    <script>
+      Reflect.defineProperty(Object.prototype, 'inspect', {
+        // get() {
+        //   const value = this.valueOf();
+        //   console.log(value);
+        //   return value;
+        // },
+        // set(value) {
+        //   Reflect.defineProperty(Object.prototype, 'inspect', {
+        //     value,
+        //     configurable: true,
+        //     writable: true,
+        //     enumerable: true,
+        //   });
+        // },
+        get() {
+          return (label, globalRef) => {
+            if (label) console.log(label, this);
+            else console.log(this);
+
+            if (globalRef) {
+              console.log(
+                `storing reference to: window.${globalRef}`,
+                (window[globalRef] = this)
+              );
+            }
+
+            return this;
+          };
+        },
+        configurable: true,
+        enumerable: false,
+      });
+    </script>
     <style type="text/css">
       /* Palette: https://flatuicolors.com/palette/defo */
 
@@ -56,6 +90,17 @@
       </table>
     </div>
     <div id="logging-controls" style="margin-top: 16px"></div>
+    <div
+      id="config-debug"
+      style="
+        position: fixed;
+        top: 0;
+        right: 0;
+        width: 300px;
+        overflow: scroll;
+        height: 100%;
+      "
+    ></div>
     <script src="/src/index.ts" async type="module"></script>
   </body>
 </html>

--- a/src/configLoader.ts
+++ b/src/configLoader.ts
@@ -1,0 +1,22 @@
+import * as constants from './constants';
+
+type ValidConfigs = typeof constants;
+type ValidConfigKeys = keyof ValidConfigs;
+
+const overrides: Partial<ValidConfigs> = {};
+
+export function fetchConfig(config: ValidConfigKeys) {
+  return Object.hasOwn(overrides, config)
+    ? overrides[config]
+    : constants[config];
+}
+
+const ConfigProxy = new Proxy(constants, {
+  get(target, handler, receiver) {
+    return Object.hasOwn(overrides, handler as ValidConfigKeys)
+      ? overrides[handler as ValidConfigKeys]
+      : constants[handler as ValidConfigKeys];
+  },
+});
+
+export const Config = ConfigProxy;

--- a/src/configLoader.ts
+++ b/src/configLoader.ts
@@ -5,10 +5,19 @@ export type ValidConfigKeys = keyof ValidConfigs;
 
 const overrides: Partial<ValidConfigs> = {};
 
+type MutableConfigs = {
+  -readonly [P in keyof ValidConfigs]: ValidConfigs[P];
+};
+
 export function fetchConfig(config: ValidConfigKeys) {
   return Object.hasOwn(overrides, config)
     ? overrides[config]
     : constants[config];
+}
+
+export function writeConfig(key: ValidConfigKeys, newValue: any) {
+  (overrides as MutableConfigs)[key] = newValue;
+  return true;
 }
 
 const ConfigProxy = new Proxy(constants, {
@@ -16,10 +25,6 @@ const ConfigProxy = new Proxy(constants, {
     return Object.hasOwn(overrides, handler as ValidConfigKeys)
       ? overrides[handler as ValidConfigKeys]
       : constants[handler as ValidConfigKeys];
-  },
-  set(target, handler, newValue) {
-    overrides[handler as ValidConfigKeys] = newValue;
-    return true;
   },
 });
 

--- a/src/configLoader.ts
+++ b/src/configLoader.ts
@@ -1,7 +1,7 @@
 import * as constants from './constants';
 
 type ValidConfigs = typeof constants;
-type ValidConfigKeys = keyof ValidConfigs;
+export type ValidConfigKeys = keyof ValidConfigs;
 
 const overrides: Partial<ValidConfigs> = {};
 
@@ -16,6 +16,10 @@ const ConfigProxy = new Proxy(constants, {
     return Object.hasOwn(overrides, handler as ValidConfigKeys)
       ? overrides[handler as ValidConfigKeys]
       : constants[handler as ValidConfigKeys];
+  },
+  set(target, handler, newValue) {
+    overrides[handler as ValidConfigKeys] = newValue;
+    return true;
   },
 });
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,5 @@
+import Phaser from 'phaser';
+
 export const BOARD_BACKGROUND_COLOR = '#16a085';
 export const BOARD_WIDTH = 640;
 export const BOARD_HEIGHT = 512;
@@ -26,6 +28,7 @@ export const WAVE_STATES = {
 
 export const TILE_SIZE = SPRITE_SIZE;
 
+export const BULLET_BASE_SPEED = Phaser.Math.GetSpeed(300, 1);
 export const BULLET_DAMAGE = 50;
 export const ENEMY_HP = 500;
 export const ENEMY_SPAWN_RATE_MS = 300;
@@ -37,6 +40,7 @@ export const HOMEBASE__SHAKE_INTENSITY = 0.0125 / 2;
 export const HOMEBASE_DAMAGED_TINT = 0xff0000;
 export const HOMEBASE_DEAD_TINT = 0x0f0f0f;
 
+export const UNIT_BASE_SPEED = Phaser.Math.GetSpeed(100, 1);
 export const UNIT_FIRE_RANGE = 100;
 export const UNIT_FIRE_RATE_MS = 100;
 export const UNIT_SNAP_DISTANCE = 2;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -102,3 +102,5 @@ export const AVAILABLE_FORMATIONS: {
 export const DEFAULT_FORMATION_SHAPE = 'auto';
 
 export const GLOBAL_KEYS__MENU_KEY = 'ESC';
+
+export const GLOBAL_KEYS__CONFIG_DEBUG = `BACKTICK`;

--- a/src/entities/Bullet.ts
+++ b/src/entities/Bullet.ts
@@ -1,5 +1,6 @@
 import Phaser, { Scene } from 'phaser';
 
+import { Config } from '../configLoader';
 import {
   SPRITE_ATLAS_NAME,
   BULLET_IMG_NAME,
@@ -20,7 +21,7 @@ class Bullet extends Phaser.Physics.Arcade.Image {
     this.dx = 0;
     this.dy = 0;
     this.lifespan = 0;
-    this.speed = Phaser.Math.GetSpeed(300, 1);
+    this.speed = Config.BULLET_BASE_SPEED;
   }
 
   setCorrectBoundingBox() {

--- a/src/entities/Bullet.ts
+++ b/src/entities/Bullet.ts
@@ -12,7 +12,6 @@ class Bullet extends Phaser.Physics.Arcade.Image {
   dx: number;
   dy: number;
   lifespan: number;
-  speed: number;
 
   _damage = 0;
 
@@ -21,7 +20,10 @@ class Bullet extends Phaser.Physics.Arcade.Image {
     this.dx = 0;
     this.dy = 0;
     this.lifespan = 0;
-    this.speed = Config.BULLET_BASE_SPEED;
+  }
+
+  speed() {
+    return Config.BULLET_BASE_SPEED;
   }
 
   setCorrectBoundingBox() {
@@ -50,8 +52,8 @@ class Bullet extends Phaser.Physics.Arcade.Image {
 
   update(time: number, delta: number) {
     this.lifespan -= delta;
-    this.x += this.dx * (this.speed * delta);
-    this.y += this.dy * (this.speed * delta);
+    this.x += this.dx * (this.speed() * delta);
+    this.y += this.dy * (this.speed() * delta);
 
     const shouldDeactivate = this.lifespan <= 0;
 

--- a/src/entities/Enemy.ts
+++ b/src/entities/Enemy.ts
@@ -5,7 +5,8 @@ import HealthBar from './HealthBar';
 
 import { generateId } from '../utils';
 
-import { ENEMY_HP, ENEMY_IMG_NAME, ENEMY_SPEED, TILE_SIZE } from '../constants';
+import { ENEMY_IMG_NAME, TILE_SIZE } from '../constants';
+import { Config } from '../configLoader';
 
 class Enemy extends Phaser.Physics.Arcade.Sprite {
   id: string;
@@ -23,9 +24,9 @@ class Enemy extends Phaser.Physics.Arcade.Sprite {
     this.id = generateId('Enemy');
 
     this.follower = { t: 0, vec: new Phaser.Math.Vector2() };
-    this.hp = ENEMY_HP;
+    this.hp = Config.ENEMY_HP;
 
-    this.healthBar = new HealthBar(scene, -100, -100, ENEMY_HP, ENEMY_HP);
+    this.healthBar = new HealthBar(scene, -100, -100, this.hp, this.hp);
     this.recycled = 0;
   }
 
@@ -34,7 +35,7 @@ class Enemy extends Phaser.Physics.Arcade.Sprite {
   }
 
   _resetValuesForRecycle() {
-    this.hp = ENEMY_HP;
+    this.hp = Config.ENEMY_HP;
     this.recycled += 1;
   }
 
@@ -69,7 +70,7 @@ class Enemy extends Phaser.Physics.Arcade.Sprite {
 
   getPositionAfterDelta(delta: number) {
     return this.enemyPath.getPoint(
-      Math.min(this.follower.t + ENEMY_SPEED * delta, 1),
+      Math.min(this.follower.t + Config.ENEMY_SPEED * delta, 1),
       this.follower.vec
     );
   }
@@ -85,7 +86,7 @@ class Enemy extends Phaser.Physics.Arcade.Sprite {
 
   update(time: number, delta: number) {
     // move the t point along the path, 0 is the start and 0 is the end
-    this.follower.t += ENEMY_SPEED * delta;
+    this.follower.t += Config.ENEMY_SPEED * delta;
 
     // get the new x and y coordinates in vec
     this.enemyPath.getPoint(this.follower.t, this.follower.vec);

--- a/src/entities/HomeBase.ts
+++ b/src/entities/HomeBase.ts
@@ -1,13 +1,7 @@
 import { Scene } from 'phaser';
-import {
-  HOMEBASE_DAMAGED_TINT,
-  HOMEBASE_DEAD_TINT,
-  HOMEBASE_HP,
-  HOMEBASE_TEXTURE_NAME,
-  HOMEBASE__SHAKE_DURATION,
-  HOMEBASE__SHAKE_INTENSITY,
-  TILE_SIZE,
-} from '../constants';
+
+import { Config } from '../configLoader';
+import { HOMEBASE_TEXTURE_NAME, TILE_SIZE } from '../constants';
 import HealthBar from './HealthBar';
 
 class HomeBase extends Phaser.GameObjects.Image {
@@ -19,7 +13,7 @@ class HomeBase extends Phaser.GameObjects.Image {
   constructor(scene: Scene) {
     super(scene, 0, 0, HOMEBASE_TEXTURE_NAME);
 
-    this.hp = HOMEBASE_HP;
+    this.hp = Config.HOMEBASE_HP;
     this.healthBar = new HealthBar(
       scene,
       this.x - TILE_SIZE / 2,
@@ -57,16 +51,16 @@ class HomeBase extends Phaser.GameObjects.Image {
     this.hp -= damage;
 
     this.scene.cameras.main.shake(
-      HOMEBASE__SHAKE_DURATION,
-      HOMEBASE__SHAKE_INTENSITY
+      Config.HOMEBASE__SHAKE_DURATION,
+      Config.HOMEBASE__SHAKE_INTENSITY
     );
 
-    this.setTint(HOMEBASE_DAMAGED_TINT);
+    this.setTint(Config.HOMEBASE_DAMAGED_TINT);
 
     // don't clober the new tint with a stale reset
     this._previousDamageTintReset?.remove();
     this._previousDamageTintReset = this.scene.time.delayedCall(
-      HOMEBASE__SHAKE_DURATION,
+      Config.HOMEBASE__SHAKE_DURATION,
       () => {
         this.clearTint();
         this._previousDamageTintReset = null;
@@ -79,7 +73,7 @@ class HomeBase extends Phaser.GameObjects.Image {
       this.hp = 0;
 
       this._previousDamageTintReset?.remove();
-      this.setTint(HOMEBASE_DEAD_TINT);
+      this.setTint(Config.HOMEBASE_DEAD_TINT);
     }
   }
 

--- a/src/entities/Pointer.ts
+++ b/src/entities/Pointer.ts
@@ -1,20 +1,14 @@
 import Phaser from 'phaser';
 import { Game } from '../scenes/Game';
 
-import {
-  TILE_SIZE,
-  INDICATOR_VALID_SELECTION_COLOR,
-  INDICATOR_INVALID_SELECTION_COLOR,
-  INDICATOR_OPACITY,
-  BOARD_HEIGHT,
-  BOARD_WIDTH,
-} from '../constants';
+import { TILE_SIZE, BOARD_HEIGHT, BOARD_WIDTH } from '../constants';
 
 import {
   getTileRowColBySceneXY,
   getValidUnitFormation,
   isTileFreeAtPosition,
 } from '../utils';
+import { Config } from '../configLoader';
 
 class Pointer extends Phaser.GameObjects.GameObject {
   indicator: Phaser.GameObjects.Graphics;
@@ -84,8 +78,8 @@ class Pointer extends Phaser.GameObjects.GameObject {
         isTileFreeAtPosition(this.x, this.y, this.gameScene().map)
       ) {
         this.indicator.fillStyle(
-          INDICATOR_VALID_SELECTION_COLOR,
-          INDICATOR_OPACITY
+          Config.INDICATOR_VALID_SELECTION_COLOR,
+          Config.INDICATOR_OPACITY
         );
 
         entities.selectedUnitGroup.getUnits().forEach((_, index) => {
@@ -98,15 +92,15 @@ class Pointer extends Phaser.GameObjects.GameObject {
         });
       } else {
         this.indicator.fillStyle(
-          INDICATOR_INVALID_SELECTION_COLOR,
-          INDICATOR_OPACITY
+          Config.INDICATOR_INVALID_SELECTION_COLOR,
+          Config.INDICATOR_OPACITY
         );
         this.indicator.fillRect(this.x, this.y, TILE_SIZE, TILE_SIZE);
       }
     } else {
       if (this.isDebugKeyDown()) {
         this.indicator
-          .fillStyle(0xffff00, INDICATOR_OPACITY)
+          .fillStyle(0xffff00, Config.INDICATOR_OPACITY)
           .fillRect(this.x, this.y, TILE_SIZE, TILE_SIZE);
 
         const col = this.x / TILE_SIZE;

--- a/src/entities/Unit.ts
+++ b/src/entities/Unit.ts
@@ -175,7 +175,7 @@ export class Unit extends Phaser.GameObjects.Image {
       // Second: using distance and speed, make a prediction
       // of when the bullet will collide with the enemy
       const futurePosition = enemy.getPositionAfterDelta(
-        approximateDistance / bullet.speed
+        approximateDistance / bullet.speed()
       );
 
       const angle = Phaser.Math.Angle.Between(

--- a/src/entities/Unit.ts
+++ b/src/entities/Unit.ts
@@ -6,13 +6,7 @@ import {
   VALID_UNIT_POSITION,
   OCCUPIED_UNIT_POSITION,
   TILE_SIZE,
-  UNIT_FIRE_RANGE,
-  UNIT_FIRE_RATE_MS,
   UNIT_SNAP_DISTANCE,
-  UNIT_MOVING_TINT,
-  UNIT_SELECTED_TILE_BORDER,
-  UNIT_PREPARING_TINT,
-  BULLET_DAMAGE,
   UNIT_IMG_NAME__NORMAL,
   UNIT_IMG_NAME__CHONKY,
   UNIT_IMG_NAME__SPEEDY,
@@ -28,6 +22,7 @@ import Bullet from './Bullet';
 import Enemy from './Enemy';
 import { TileHighlight } from './TileHighlight';
 import { ACTIONS, STATES, boundStateMachine } from './UnitStateMachine';
+import { Config } from '../configLoader';
 
 const logger = getLogger('UNIT_ENTITY');
 
@@ -65,7 +60,7 @@ export class Unit extends Phaser.GameObjects.Image {
     logger.log('### NEW TANKY', this);
 
     this.target = new Phaser.Math.Vector2();
-    this.speed = Phaser.Math.GetSpeed(100, 1);
+    this.speed = Config.UNIT_BASE_SPEED;
     this.nextTick = 0;
     this.isSelected = false;
     this._queuedPath = [];
@@ -74,7 +69,11 @@ export class Unit extends Phaser.GameObjects.Image {
     this._machine = boundStateMachine(this);
     this._machine.start();
 
-    this.highlight = new TileHighlight(scene, 2, UNIT_SELECTED_TILE_BORDER);
+    this.highlight = new TileHighlight(
+      scene,
+      2,
+      Config.UNIT_SELECTED_TILE_BORDER
+    );
 
     this.on(
       Phaser.Input.Events.POINTER_DOWN as string,
@@ -88,15 +87,15 @@ export class Unit extends Phaser.GameObjects.Image {
   }
 
   getDamage() {
-    return BULLET_DAMAGE;
+    return Config.BULLET_DAMAGE;
   }
 
   getFireRange() {
-    return UNIT_FIRE_RANGE;
+    return Config.UNIT_FIRE_RANGE;
   }
 
   getFireRate() {
-    return UNIT_FIRE_RATE_MS;
+    return Config.UNIT_FIRE_RATE_MS;
   }
 
   getMovementSpeed() {
@@ -308,9 +307,9 @@ export class Unit extends Phaser.GameObjects.Image {
     const entities = this.gameScene().entities;
 
     if (this.isMoving()) {
-      this.setTint(UNIT_MOVING_TINT);
+      this.setTint(Config.UNIT_MOVING_TINT);
     } else if (this.isPreparing()) {
-      this.setTint(UNIT_PREPARING_TINT);
+      this.setTint(Config.UNIT_PREPARING_TINT);
     } else {
       this.clearTint();
     }
@@ -433,17 +432,17 @@ export class ChonkyUnit extends Unit {
   }
 
   getDamage() {
-    return BULLET_DAMAGE * 4;
+    return Config.BULLET_DAMAGE * 4;
   }
 
   getFireRange() {
-    return (UNIT_FIRE_RANGE * 2) / 3;
+    return (Config.UNIT_FIRE_RANGE * 2) / 3;
   }
 
   getFireRate() {
     // TODO: different burst options, current only double-tap
     this.__fireRateToggle = !this.__fireRateToggle;
-    return UNIT_FIRE_RATE_MS * (this.__fireRateToggle ? 1 : 2);
+    return Config.UNIT_FIRE_RATE_MS * (this.__fireRateToggle ? 1 : 2);
   }
 
   getMovementSpeed() {
@@ -457,15 +456,15 @@ export class SpeedyUnit extends Unit {
   }
 
   getDamage() {
-    return BULLET_DAMAGE / 4;
+    return Config.BULLET_DAMAGE / 4;
   }
 
   getFireRange() {
-    return UNIT_FIRE_RANGE;
+    return Config.UNIT_FIRE_RANGE;
   }
 
   getFireRate() {
-    return UNIT_FIRE_RATE_MS / 2;
+    return Config.UNIT_FIRE_RATE_MS / 2;
   }
 
   getMovementSpeed() {
@@ -479,15 +478,15 @@ export class SnipeyUnit extends Unit {
   }
 
   getDamage() {
-    return BULLET_DAMAGE * 2;
+    return Config.BULLET_DAMAGE * 2;
   }
 
   getFireRange() {
-    return UNIT_FIRE_RANGE * 3;
+    return Config.UNIT_FIRE_RANGE * 3;
   }
 
   getFireRate() {
-    return UNIT_FIRE_RATE_MS * 6;
+    return Config.UNIT_FIRE_RATE_MS * 6;
   }
 
   getMovementSpeed() {
@@ -501,7 +500,7 @@ export const UnitType = {
   NORMAL: Unit,
   SPEEDY: SpeedyUnit,
   CHONKY: ChonkyUnit,
-  SNIPEY: SnipeyUnit
+  SNIPEY: SnipeyUnit,
 };
 
 export type UnitTypeOption = keyof typeof UnitType;

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,9 +13,11 @@ import { Game } from './scenes/Game';
 import { MainMenu } from './scenes/MainMenu';
 import { PauseMenu } from './scenes/PauseMenu';
 import { GameOver } from './scenes/GameOver';
+import { ConfigDebugMenu } from './scenes/ConfigDebugMenu';
 
 const config: Phaser.Types.Core.GameConfig = {
   backgroundColor: BOARD_BACKGROUND_COLOR,
+  dom: { createContainer: true, pointerEvents: '' },
   scale: {
     mode: Phaser.Scale.FIT,
     parent: 'content',
@@ -29,7 +31,7 @@ const config: Phaser.Types.Core.GameConfig = {
     },
     default: 'arcade',
   },
-  scene: [MainMenu, Game, PauseMenu, GameOver],
+  scene: [MainMenu, Game, ConfigDebugMenu, PauseMenu, GameOver],
 };
 
 new Phaser.Game(config);

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ const config: Phaser.Types.Core.GameConfig = {
 
 new Phaser.Game(config);
 
-(function loadDebugLoggerConfigurations() {
+function loadDebugLoggerConfigurations() {
   const LOG_CONFIG_KEY = '__log_config';
   const LOGGING_CONFIG: Record<string, boolean> = {};
   let loggingConfigOverrides: Record<string, boolean> = {};
@@ -64,6 +64,8 @@ new Phaser.Game(config);
     (key) => (isAllEnabled = isAllEnabled && LOGGING_CONFIG[key])
   );
 
+  synchronizeConfigs();
+
   document.querySelector(
     '#logging-controls'
   )!.innerHTML = `<table style="margin: auto">
@@ -89,6 +91,12 @@ new Phaser.Game(config);
           })
           .join('')}</table>`;
 
+  function synchronizeConfigs() {
+    LOGGING_KEYS_ALL.forEach((currKey) => {
+      setLoggingConfig(currKey, LOGGING_CONFIG[currKey]);
+    });
+  }
+
   document
     .querySelector('#logging-controls')!
     .addEventListener('click', (event) => {
@@ -105,9 +113,9 @@ new Phaser.Game(config);
 
         LOGGING_KEYS_ALL.forEach((key) => {
           LOGGING_CONFIG[key] = target.checked;
-          setLoggingConfig(key as LOGGING_KEYS, target.checked);
         });
 
+        synchronizeConfigs();
         updateSearchParamKey(LOG_CONFIG_KEY, JSON.stringify(LOGGING_CONFIG));
       }
 
@@ -116,4 +124,6 @@ new Phaser.Game(config);
 
       updateSearchParamKey(LOG_CONFIG_KEY, JSON.stringify(LOGGING_CONFIG));
     });
-})();
+}
+
+loadDebugLoggerConfigurations();

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import { ConfigDebugMenu } from './scenes/ConfigDebugMenu';
 
 const config: Phaser.Types.Core.GameConfig = {
   backgroundColor: BOARD_BACKGROUND_COLOR,
-  dom: { createContainer: true, pointerEvents: '' },
+  dom: { createContainer: true },
   scale: {
     mode: Phaser.Scale.FIT,
     parent: 'content',

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,5 +1,6 @@
 const LOGGING_CONFIG = {
   _ENABLE_ALL: false,
+  CONFIG_DEBUG: true,
   DEBUG_HUD__KEYBOARD_STATUS: false,
   DEBUG_HUD__UNIT_STATUS: false,
   DEBUG_HUD__HOME_BASE_HP: false,
@@ -11,9 +12,9 @@ const LOGGING_CONFIG = {
   POINTER_UI_DEBUG: false,
 };
 
-export const LOGGING_KEYS_ALL = Object.keys(LOGGING_CONFIG);
-
 export type LOGGING_KEYS = keyof Omit<typeof LOGGING_CONFIG, '_ENABLE_ALL'>;
+
+export const LOGGING_KEYS_ALL = Object.keys(LOGGING_CONFIG) as LOGGING_KEYS[];
 
 export function getLoggingConfig(key: LOGGING_KEYS) {
   return LOGGING_CONFIG[key];

--- a/src/scenes/ConfigDebugMenu.ts
+++ b/src/scenes/ConfigDebugMenu.ts
@@ -1,0 +1,65 @@
+import { Config, ValidConfigKeys } from '../configLoader';
+
+export const title = 'config-debug-menu';
+
+export class ConfigDebugMenu extends Phaser.Scene {
+  constructor() {
+    super(title);
+  }
+
+  create() {
+    // this.input.on(
+    //   Phaser.Input.Events.POINTER_DOWN as string,
+    //   this.handleToggleMenu,
+    //   this
+    // );
+
+    // this.input.keyboard.on(`keydown-BACKTICK`, this.handleToggleMenu, this);
+
+    function handleConfigChange(event: Event) {
+      const target = event.target as HTMLInputElement;
+
+      const key = target.id as ValidConfigKeys;
+      const value = target.classList.contains('number')
+        ? parseFloat(target.value)
+        : target.value;
+
+      const oldValue = Config[key];
+      Config[key] = value;
+      console.log(
+        `updated ${key} to be ${value}, old value was: ${oldValue as string}`
+      );
+    }
+
+    function renderConfig(configKey: ValidConfigKeys, configValue: any) {
+      if (typeof configValue === 'object') return '';
+
+      const className = isNaN(configValue as number) ? 'text' : 'number';
+      return `
+        <label for="${configKey}">${configKey}</label>
+        <input id="${configKey}" class="${className}" type="text" value="${
+        configValue as string
+      }" />
+      `;
+    }
+
+    const configDump = document.querySelector('#config-debug')!;
+    configDump.innerHTML = `
+      <h3 style="margin-bottom: 0; ">Debug Config Values</h3>
+      <div class="value-container" style="width: 100%; white-space: pre-line;">
+       ${(Object.keys(Config) as ValidConfigKeys[])
+         .map((key) => renderConfig(key, Config[key]))
+         .join('\n')}
+        <pre style="display: none">${JSON.stringify(Config, null, 2)}</pre>
+      </div>
+    `;
+
+    document
+      .querySelector('.value-container')!
+      .addEventListener('change', handleConfigChange);
+  }
+
+  // handleToggleMenu = () => {
+  //   this.scene.stop();
+  // };
+}

--- a/src/scenes/ConfigDebugMenu.ts
+++ b/src/scenes/ConfigDebugMenu.ts
@@ -3,19 +3,13 @@ import { Config, ValidConfigKeys } from '../configLoader';
 export const title = 'config-debug-menu';
 
 export class ConfigDebugMenu extends Phaser.Scene {
+  CONFIG_CONTAINER = '#config-debug';
+
   constructor() {
     super(title);
   }
 
   create() {
-    // this.input.on(
-    //   Phaser.Input.Events.POINTER_DOWN as string,
-    //   this.handleToggleMenu,
-    //   this
-    // );
-
-    // this.input.keyboard.on(`keydown-BACKTICK`, this.handleToggleMenu, this);
-
     function handleConfigChange(event: Event) {
       const target = event.target as HTMLInputElement;
 
@@ -43,7 +37,7 @@ export class ConfigDebugMenu extends Phaser.Scene {
       `;
     }
 
-    const configDump = document.querySelector('#config-debug')!;
+    const configDump = document.querySelector(this.CONFIG_CONTAINER)!;
     configDump.innerHTML = `
       <h3 style="margin-bottom: 0; ">Debug Config Values</h3>
       <div class="value-container" style="width: 100%; white-space: pre-line;">
@@ -57,9 +51,12 @@ export class ConfigDebugMenu extends Phaser.Scene {
     document
       .querySelector('.value-container')!
       .addEventListener('change', handleConfigChange);
+
+    // called when the scene is `stopped`
+    this.events.on('shutdown', this.hideConfigs, this);
   }
 
-  // handleToggleMenu = () => {
-  //   this.scene.stop();
-  // };
+  hideConfigs = () => {
+    document.querySelector(this.CONFIG_CONTAINER)!.innerHTML = '';
+  };
 }

--- a/src/scenes/Game.ts
+++ b/src/scenes/Game.ts
@@ -23,14 +23,11 @@ import {
   BOARD_WIDTH,
   ENEMY_IMG_NAME,
   ENEMY_PATH,
-  ENEMY_SPAWN_RATE_MS,
   ENEMY_SPEED,
   GLOBAL_KEYS__MENU_KEY,
   HOMEBASE_TEXTURE_NAME,
   INVALID_UNIT_POSITION,
   OCCUPIED_UNIT_POSITION,
-  SELECTION_RECTANGLE_COLOR,
-  SELECTION_RECTANGLE_OPACITY,
   SFX_ENEMY_DEATH,
   SFX_SPRITE_SHEET,
   SPRITE_ATLAS_NAME,
@@ -45,6 +42,7 @@ import HomeBase from '../entities/HomeBase';
 import { sliceFromTexture } from '../texture-utils';
 import { TileProperties } from '../entities/Map';
 import { Button } from '../entities/Button';
+import { Config } from '../configLoader';
 
 class LevelConfig {
   tilemapKey: string;
@@ -479,7 +477,7 @@ export class Game extends Phaser.Scene {
           enemy.setVisible(true);
           enemy.startOnPath(this.enemyPath);
 
-          this.nextEnemy = time + ENEMY_SPAWN_RATE_MS;
+          this.nextEnemy = time + Config.ENEMY_SPAWN_RATE_MS;
           this.enemiesSpawned += 1;
           this.enemiesRemainingInWave -= 1;
         }
@@ -798,8 +796,8 @@ export class Game extends Phaser.Scene {
         0,
         0,
         0,
-        SELECTION_RECTANGLE_COLOR,
-        SELECTION_RECTANGLE_OPACITY
+        Config.SELECTION_RECTANGLE_COLOR,
+        Config.SELECTION_RECTANGLE_OPACITY
       )
       .setDepth(1);
   }

--- a/src/scenes/Game.ts
+++ b/src/scenes/Game.ts
@@ -8,6 +8,7 @@ import Pointer from '../entities/Pointer';
 
 import { EntityManager, entityManagerFactory } from '../entities';
 
+import { title as ConfigDebugMenuScene } from './ConfigDebugMenu';
 import { title as PauseMenuScene } from './PauseMenu';
 import { title as GameOverScene } from './GameOver';
 
@@ -24,6 +25,7 @@ import {
   ENEMY_IMG_NAME,
   ENEMY_PATH,
   ENEMY_SPEED,
+  GLOBAL_KEYS__CONFIG_DEBUG,
   GLOBAL_KEYS__MENU_KEY,
   HOMEBASE_TEXTURE_NAME,
   INVALID_UNIT_POSITION,
@@ -296,6 +298,14 @@ export class Game extends Phaser.Scene {
     this.input.keyboard.on(`keydown-${GLOBAL_KEYS__MENU_KEY}`, () => {
       this.scene.pause();
       this.scene.launch(PauseMenuScene);
+    });
+
+    this.input.keyboard.on(`keydown-${GLOBAL_KEYS__CONFIG_DEBUG}`, () => {
+      if (this.scene.isActive(ConfigDebugMenuScene)) {
+        this.scene.stop(ConfigDebugMenuScene);
+      } else {
+        this.scene.launch(ConfigDebugMenuScene);
+      }
     });
 
     this.input.on(


### PR DESCRIPTION
* use config proxy to fetch config values (so we can store overrides)
* add UI to expose all config values
  * for input values pressing enter commits the new value to the game (there is a console log for confirmation)
  * text and number/decimal is handled appropriately
* config debugger persists to localStorage (inspect via `window.localStorage.__configOverrides`) if you enabled persistence via debug flag: `persist-config-debug`
  * http://localhost:3000/?quick-start=false&persist-config-debug=true

https://user-images.githubusercontent.com/11997716/204118615-fcfcb482-a311-44e9-80ae-ebf573798f69.mov


### TODO:
- [x] how to do config persistence?